### PR TITLE
Refactor models to remove derive_builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Cargo.lock
 # Added by cargo
 
 /target
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["financial", "payments", "message", "iso20022", "processor"]
 categories = ["data-structures", "development-tools", "finance", "parsing", "parser-implementations"]
 
 [dependencies]
-derive_builder = "0.20.2"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.70"
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,10 +1,18 @@
 use core_data::models::message::*;
+use core_data::models::payload::*;
 
 fn main() {
     // Create a Message instance using the builder pattern
-    let message = MessageBuilder::default()
-        .build()
-        .unwrap();
+    let message = Message::new(
+        Payload::new_inline(
+            Some(serde_json::json!({"key": "value"})),
+            PayloadFormat::Json,
+            Encoding::Utf8,
+        ),
+        "tenant".to_string(),
+        "origin".to_string(),
+        None,
+    );
 
     // Serialize the Message instance to a JSON string
     let serialized = serde_json::to_string_pretty(&message).unwrap();

--- a/src/models/auditlog.rs
+++ b/src/models/auditlog.rs
@@ -1,56 +1,71 @@
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use derive_builder::Builder;
 use sonyflake::Sonyflake;
 
-#[derive(Debug, Serialize, Deserialize, Builder, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct AuditLog {
     /// Unique identifier for the audit log
     #[serde(rename = "id")]
-    #[builder(default = "Sonyflake::new().unwrap().next_id().unwrap()")]
     pub id: u64,
 
     #[serde(with = "time::serde::iso8601")]
-    #[builder(default = "OffsetDateTime::UNIX_EPOCH")]
     pub timestamp: OffsetDateTime,
 
-    #[builder(default = "String::from(\"\")")]
     pub workflow: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub task: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub description: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub hash: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub service: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub instance: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub version: String,
 
-    #[builder(default = "Vec::new()")]
     pub changes: Vec<ChangeLog>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Builder, Clone, PartialEq)]
+impl AuditLog {
+    pub fn new() -> Self {
+        let sf = Sonyflake::new().unwrap();
+        let id = sf.next_id().unwrap();
+        let timestamp = OffsetDateTime::now_utc();
+        AuditLog {
+            id,
+            timestamp,
+            workflow: "".to_string(),
+            task: "".to_string(),
+            description: "".to_string(),
+            hash: "".to_string(),
+            service: "".to_string(),
+            instance: "".to_string(),
+            version: "".to_string(),
+            changes: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ChangeLog {
-    #[builder(default = "String::from(\"\")")]
     pub field: String,
 
-    #[builder(default = "None")]
     pub old_value: Option<serde_json::Value>,
 
-    #[builder(default = "None")]
     pub new_value: Option<serde_json::Value>,
 
-    #[builder(default = "String::from(\"\")")]
     pub reason: String,
+}
 
+impl ChangeLog {
+    pub fn new() -> Self {
+        ChangeLog {
+            field: "".to_string(),
+            old_value: None,
+            new_value: None,
+            reason: "".to_string(),
+        }
+    }
 }

--- a/src/models/message.rs
+++ b/src/models/message.rs
@@ -1,64 +1,92 @@
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use derive_builder::Builder;
 use crate::models::payload::*;
 use crate::models::auditlog::*;
 use sonyflake::Sonyflake;
 
-#[derive(Debug, Serialize, Deserialize, Builder, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Message {
     /// Unique identifier for the message
     #[serde(rename = "id")]
-    #[builder(default = "Sonyflake::new().unwrap().next_id().unwrap()")]
     pub id: u64,
 
-    #[builder(default = "None")]
     pub parent_id: Option<String>,
 
     /// Message payload containing content or reference
-    #[builder(default = "PayloadBuilder::default().build().unwrap()")]
     pub payload: Payload,
     
     /// Tenant identifier
-    #[builder(default = "String::from(\"\")")]
     pub tenant: String,
     
     /// Origin of the message
-    #[builder(default = "String::from(\"\")")]
     pub origin: String,
     
     /// Message data
-    #[builder(default = "serde_json::json!({})")]
     pub data: serde_json::Value,
     
     /// Progress information
-    #[builder(default = "ProgressBuilder::default().build().unwrap()")]
     pub progress: Progress,
 
-    #[builder(default = "Vec::new()")]
     pub audit: Vec<AuditLog>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Builder, Clone, PartialEq)]
+impl Message {
+    pub fn new(payload: Payload, tenant: String, origin: String, message_alias: Option<String>) -> Self {
+        let sf = Sonyflake::new().unwrap();
+        let id = sf.next_id().unwrap();
+
+        let alias = message_alias.unwrap_or_else(|| "Message".to_string());
+        let description = alias
+            .chars()
+            .next()
+            .map(|c| c.to_uppercase().collect::<String>() + &alias[1..])
+            .unwrap_or_else(|| "Message".to_string()) + " created";
+        let reason = "Initial message creation for ".to_string() + &alias.to_lowercase();
+
+        let mut audit = AuditLog::new();
+        audit.description = description;
+        audit.changes.push(ChangeLog {
+            field: "payload".to_string(),
+            old_value: None,
+            new_value: None,
+            reason,
+        });
+
+        Self {
+            id,
+            parent_id: None,
+            payload,
+            tenant,
+            origin,
+            data: serde_json::Value::Null,
+            progress: Progress {
+                status: MessageStatus::Recieved,
+                workflow_id: "".to_string(),
+                prev_task: "".to_string(),
+                prev_status_code: "".to_string(),
+                timestamp: OffsetDateTime::now_utc(),
+            },
+            audit: vec![audit],
+        }
+    }
+    
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Progress {
-    #[builder(default = "MessageStatus::Recieved")]
     pub status: MessageStatus,
 
     /// Workflow definition identifier
-    #[builder(default = "String::from(\"\")")]
     pub workflow_id: String,
 
     /// Last completed task identifier
-    #[builder(default = "String::from(\"\")")]
     pub prev_task: String,
     
     /// Status code from last task
-    #[builder(default = "String::from(\"\")")]
     pub prev_status_code: String,
     
     /// Timestamp of last completion
     #[serde(with = "time::serde::iso8601")]
-    #[builder(default = "OffsetDateTime::UNIX_EPOCH")]
     pub timestamp: OffsetDateTime,
 }
 

--- a/src/models/payload.rs
+++ b/src/models/payload.rs
@@ -1,34 +1,51 @@
 use serde::{Deserialize, Serialize};
-use derive_builder::Builder;
 
-#[derive(Debug, Serialize, Deserialize, Builder, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Payload {
     /// Storage type: inline or file
     #[serde(rename = "type")]
-    #[builder(default = "PayloadType::Inline")]
     pub payload_type: PayloadType,
     
     /// Actual content when stored inline
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default = "None")]
     pub content: Option<serde_json::Value>,
     
     /// URL for external content
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default = "None")]
     pub url: Option<String>,
     
     /// Content format
-    #[builder(default = "PayloadFormat::Xml")]
     pub format: PayloadFormat,
     
     /// Character encoding
-    #[builder(default = "Encoding::Utf8")]
     pub encoding: Encoding,
     
     /// Size in bytes
-    #[builder(default = "0")]
     pub size: i64,
+}
+
+impl Payload {
+    pub fn new_inline(content: Option<serde_json::Value>, format: PayloadFormat, encoding: Encoding) -> Self {
+        Self {
+            payload_type: PayloadType::Inline,
+            content,
+            url: None,
+            format,
+            encoding,
+            size: 0,
+        }
+    }
+
+    pub fn new_file(url: Option<String>, format: PayloadFormat, encoding: Encoding, size: i64) -> Self {
+        Self {
+            payload_type: PayloadType::File,
+            content: None,
+            url,
+            format,
+            encoding,
+            size,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -1,27 +1,21 @@
 use serde::{Deserialize, Serialize};
-use derive_builder::Builder;
 
 
-#[derive(Debug, Serialize, Deserialize, Builder, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Task {
-    #[builder(default = "String::from(\"\")")]
     pub task_id: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub name: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub description: String,
 
-    #[builder(default = "serde_json::json!({})")]
-    pub trigger_condition: serde_json::Value,
+    pub condition: serde_json::Value,
 
-    #[builder(default = "FunctionType::Validate")]
     pub function: FunctionType,
 
-    #[builder(default = "serde_json::json!({})")]
     pub input: serde_json::Value,
 }
+
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum FunctionType {

--- a/src/models/workflow.rs
+++ b/src/models/workflow.rs
@@ -1,28 +1,23 @@
 use serde::{Deserialize, Serialize};
-use derive_builder::Builder;
 use crate::models::task::*;
 
 
-#[derive(Debug, Serialize, Deserialize, Builder, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Workflow {
-    #[builder(default = "String::from(\"\")")]
     pub name: String,
 
-    #[builder(default = "String::from(\"\")")]
     pub description: String,
 
-    #[builder(default = "0")]
     pub version: u16,
 
-    #[builder(default = "Vec::new()")]
     pub tags: Vec<String>,
 
     #[serde(rename = "status")]
-    #[builder(default = "WorkflowStatus::Draft")]
     pub status: WorkflowStatus,
 
-    #[builder(default = "Vec::new()")]
     pub tasks: Vec<Task>,
+
+    pub condition: serde_json::Value,
 }
 
 

--- a/tests/message-test.rs
+++ b/tests/message-test.rs
@@ -1,151 +1,66 @@
-use time::OffsetDateTime;
-use core_data::models::payload::*;
-use core_data::models::auditlog::*;
-use core_data::models::message::*;
 use serde_json::json;
+use time::OffsetDateTime;
+use core_data::models::message::*;
+use core_data::models::payload::*;
+use sonyflake::Sonyflake;
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_message_builder_defaults() {
-        let message = MessageBuilder::default().build().unwrap();
-        
-        assert!(message.id > 0);
-        assert_eq!(message.parent_id, None);
-        assert_eq!(message.payload.payload_type, PayloadType::Inline);
-        assert_eq!(message.payload.content, None);
-        assert_eq!(message.payload.url, None);
-        assert_eq!(message.payload.format, PayloadFormat::Xml);
-        assert_eq!(message.payload.encoding, Encoding::Utf8);
-        assert_eq!(message.payload.size, 0);
-        assert_eq!(message.tenant, "");
-        assert_eq!(message.origin, "");
-        assert_eq!(message.data, json!({}));
-        assert_eq!(message.progress.status, MessageStatus::Recieved);
-        assert_eq!(message.progress.workflow_id, "");
-        assert_eq!(message.progress.prev_task, "");
-        assert_eq!(message.progress.prev_status_code, "");
-        assert_eq!(message.progress.timestamp, OffsetDateTime::UNIX_EPOCH);
-        assert!(message.audit.is_empty());
-    }
-
-    #[test]
-    fn test_message_custom_values() {
-        let payload = PayloadBuilder::default()
-            .payload_type(PayloadType::File)
-            .url(Some(String::from("http://example.com")))
-            .format(PayloadFormat::Json)
-            .encoding(Encoding::Utf16)
-            .size(1024)
-            .build()
-            .unwrap();
-
-        let progress = ProgressBuilder::default()
-            .status(MessageStatus::Processing)
-            .workflow_id(String::from("workflow_123"))
-            .prev_task(String::from("task_1"))
-            .prev_status_code(String::from("200"))
-            .timestamp(OffsetDateTime::now_utc())
-            .build()
-            .unwrap();
-
-        let audit_log = AuditLogBuilder::default()
-            .workflow(String::from("workflow_123"))
-            .task(String::from("task_1"))
-            .description(String::from("Task completed"))
-            .hash(String::from("hash_123"))
-            .service(String::from("service_1"))
-            .instance(String::from("instance_1"))
-            .version(String::from("v1"))
-            .build()
-            .unwrap();
-
-        let message = MessageBuilder::default()
-            .parent_id(Some(String::from("parent_123")))
-            .payload(payload)
-            .tenant(String::from("tenant_1"))
-            .origin(String::from("origin_1"))
-            .data(json!({"key": "value"}))
-            .progress(progress)
-            .audit(vec![audit_log])
-            .build()
-            .unwrap();
-
-        assert_eq!(message.parent_id, Some(String::from("parent_123")));
-        assert_eq!(message.payload.payload_type, PayloadType::File);
-        assert_eq!(message.payload.url, Some(String::from("http://example.com")));
-        assert_eq!(message.payload.format, PayloadFormat::Json);
-        assert_eq!(message.payload.encoding, Encoding::Utf16);
-        assert_eq!(message.payload.size, 1024);
-        assert_eq!(message.tenant, String::from("tenant_1"));
-        assert_eq!(message.origin, String::from("origin_1"));
-        assert_eq!(message.data, json!({"key": "value"}));
-        assert_eq!(message.progress.status, MessageStatus::Processing);
-        assert_eq!(message.progress.workflow_id, String::from("workflow_123"));
-        assert_eq!(message.progress.prev_task, String::from("task_1"));
-        assert_eq!(message.progress.prev_status_code, String::from("200"));
-        assert!(message.progress.timestamp > OffsetDateTime::UNIX_EPOCH);
-        assert_eq!(message.audit.len(), 1);
-        assert_eq!(message.audit[0].workflow, String::from("workflow_123"));
-    }
-
-    #[test]
-    fn test_message_empty_payload() {
-        let payload = PayloadBuilder::default()
-            .payload_type(PayloadType::Inline)
-            .content(None)
-            .url(None)
-            .format(PayloadFormat::Xml)
-            .encoding(Encoding::Utf8)
-            .size(0)
-            .build()
-            .unwrap();
-
-        let message = MessageBuilder::default()
-            .payload(payload)
-            .build()
-            .unwrap();
-
-        assert_eq!(message.payload.payload_type, PayloadType::Inline);
-        assert_eq!(message.payload.content, None);
-        assert_eq!(message.payload.url, None);
-        assert_eq!(message.payload.format, PayloadFormat::Xml);
-        assert_eq!(message.payload.encoding, Encoding::Utf8);
-        assert_eq!(message.payload.size, 0);
-    }
-
-    #[test]
     fn test_message_invalid_timestamp() {
-        let progress = ProgressBuilder::default()
-            .timestamp(OffsetDateTime::UNIX_EPOCH - time::Duration::seconds(1))
-            .build()
-            .unwrap();
+        let progress = Progress {
+            status: MessageStatus::Recieved,
+            workflow_id: String::new(),
+            prev_task: String::new(),
+            prev_status_code: String::new(),
+            timestamp: OffsetDateTime::UNIX_EPOCH - time::Duration::seconds(1),
+        };
 
-        let message = MessageBuilder::default()
-            .progress(progress)
-            .build()
-            .unwrap();
+        let message = Message {
+            id: Sonyflake::new().unwrap().next_id().unwrap(),
+            parent_id: None,
+            payload: Payload::new_inline(None, PayloadFormat::Json, Encoding::Utf8),
+            tenant: String::new(),
+            origin: String::new(),
+            data: serde_json::Value::Null,
+            progress,
+            audit: vec![],
+        };
 
         assert!(message.progress.timestamp < OffsetDateTime::UNIX_EPOCH);
     }
 
     #[test]
     fn test_message_large_payload() {
-        let large_content = serde_json::json!(vec!["a"; 10_000]);
+        let large_content = json!(vec!["a"; 10_000]);
         let content_size = serde_json::to_string(&large_content).unwrap().len() as i64;
-        let payload = PayloadBuilder::default()
-            .payload_type(PayloadType::Inline)
-            .content(Some(large_content.clone()))
-            .size(large_content.to_string().len() as i64)
-            .build()
-            .unwrap();
+        let payload = Payload {
+            payload_type: PayloadType::Inline,
+            content: Some(large_content.clone()),
+            url: None,
+            format: PayloadFormat::Json,
+            encoding: Encoding::Utf8,
+            size: content_size,
+        };
 
-        let message = MessageBuilder::default()
-            .payload(payload)
-            .build()
-            .unwrap();
+        let message = Message {
+            id: Sonyflake::new().unwrap().next_id().unwrap(),
+            parent_id: None,
+            payload,
+            tenant: String::new(),
+            origin: String::new(),
+            data: serde_json::Value::Null,
+            progress: Progress {
+                status: MessageStatus::Recieved,
+                workflow_id: String::new(),
+                prev_task: String::new(),
+                prev_status_code: String::new(),
+                timestamp: OffsetDateTime::now_utc(),
+            },
+            audit: vec![],
+        };
 
         assert_eq!(message.payload.content, Some(large_content));
         assert_eq!(message.payload.size, content_size);

--- a/tests/workflow-test.rs
+++ b/tests/workflow-test.rs
@@ -1,5 +1,4 @@
 use serde_json::json;
-
 use core_data::models::workflow::*;
 use core_data::models::task::*;
 
@@ -8,38 +7,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_workflow_builder_defaults() {
-        let workflow = WorkflowBuilder::default().build().unwrap();
-
-        assert_eq!(workflow.name, "");
-        assert_eq!(workflow.description, "");
-        assert_eq!(workflow.version, 0);
-        assert!(workflow.tags.is_empty());
-        assert_eq!(workflow.status, WorkflowStatus::Draft);
-        assert!(workflow.tasks.is_empty());
-    }
-
-    #[test]
     fn test_workflow_custom_values() {
-        let task = TaskBuilder::default()
-            .task_id(String::from("task_1"))
-            .name(String::from("Task 1"))
-            .description(String::from("First task"))
-            .trigger_condition(json!({"condition": "value"}))
-            .function(FunctionType::Validate)
-            .build()
-            .unwrap();
-
-        let workflow = WorkflowBuilder::default()
-            .name(String::from("Workflow 1"))
-            .description(String::from("Test workflow"))
-            .version(1)
-            .tags(vec![String::from("tag1"), String::from("tag2")])
-            .status(WorkflowStatus::Active)
-            .tasks(vec![task.clone()])
-            .build()
-            .unwrap();
-
+        let task = Task {
+            task_id: String::from("task_1"),
+            name: String::from("Task 1"),
+            description: String::from("First task"),
+            condition: json!({"condition": "value"}),
+            function: FunctionType::Validate,
+            input: json!({"input": "value"}),
+        };
+        let workflow = Workflow {
+            name: String::from("Workflow 1"),
+            description: String::from("Test workflow"),
+            version: 1,
+            tags: vec![String::from("tag1"), String::from("tag2")],
+            status: WorkflowStatus::Active,
+            tasks: vec![task.clone()],
+            condition: json!({"condition": "value"}),
+        };
         assert_eq!(workflow.name, String::from("Workflow 1"));
         assert_eq!(workflow.description, String::from("Test workflow"));
         assert_eq!(workflow.version, 1);
@@ -51,12 +36,15 @@ mod tests {
 
     #[test]
     fn test_workflow_empty_tasks() {
-        let workflow = WorkflowBuilder::default()
-            .name(String::from("Empty Workflow"))
-            .description(String::from("Workflow with no tasks"))
-            .build()
-            .unwrap();
-
+        let workflow = Workflow {
+            name: String::from("Empty Workflow"),
+            description: String::from("Workflow with no tasks"),
+            version: 0,
+            tags: vec![],
+            status: WorkflowStatus::Draft,
+            tasks: vec![],
+            condition: json!({"condition": "value"}),
+        };
         assert_eq!(workflow.name, String::from("Empty Workflow"));
         assert_eq!(workflow.description, String::from("Workflow with no tasks"));
         assert!(workflow.tasks.is_empty());
@@ -64,31 +52,31 @@ mod tests {
 
     #[test]
     fn test_workflow_multiple_tasks() {
-        let task1 = TaskBuilder::default()
-            .task_id(String::from("task_1"))
-            .name(String::from("Task 1"))
-            .description(String::from("First task"))
-            .trigger_condition(json!({"condition": "value"}))
-            .function(FunctionType::Validate)
-            .build()
-            .unwrap();
-
-        let task2 = TaskBuilder::default()
-            .task_id(String::from("task_2"))
-            .name(String::from("Task 2"))
-            .description(String::from("Second task"))
-            .trigger_condition(json!({"condition": "value"}))
-            .function(FunctionType::Enrich)
-            .build()
-            .unwrap();
-
-        let workflow = WorkflowBuilder::default()
-            .name(String::from("Workflow with Multiple Tasks"))
-            .description(String::from("Workflow containing multiple tasks"))
-            .tasks(vec![task1.clone(), task2.clone()])
-            .build()
-            .unwrap();
-
+        let task1 = Task {
+            task_id: String::from("task_1"),
+            name: String::from("Task 1"),
+            description: String::from("First task"),
+            condition: json!({"condition": "value"}),
+            function: FunctionType::Validate,
+            input: json!({"input": "value"}),
+        };
+        let task2 = Task {
+            task_id: String::from("task_2"),
+            name: String::from("Task 2"),
+            description: String::from("Second task"),
+            condition: json!({"condition": "value"}),
+            function: FunctionType::Enrich,
+            input: json!({"input": "value"}),
+        };
+        let workflow = Workflow {
+            name: String::from("Workflow with Multiple Tasks"),
+            description: String::from("Workflow containing multiple tasks"),
+            version: 0,
+            tags: vec![],
+            status: WorkflowStatus::Draft,
+            tasks: vec![task1.clone(), task2.clone()],
+            condition: json!({"condition": "value"}),
+        };
         assert_eq!(workflow.name, String::from("Workflow with Multiple Tasks"));
         assert_eq!(workflow.description, String::from("Workflow containing multiple tasks"));
         assert_eq!(workflow.tasks.len(), 2);


### PR DESCRIPTION
Refactor models to remove derive_builder usage and implement custom constructors for Payload, Message, and AuditLog; update example usage